### PR TITLE
Support keyboard controls

### DIFF
--- a/__tests__/InteractionModal.js
+++ b/__tests__/InteractionModal.js
@@ -77,6 +77,39 @@ describe('triggers callbacks', () => {
     expect(onCancel)
       .toBeCalled();
   });
+
+  describe('supports keyboard controls', () => {
+
+    it('calls onOk on pressing enter', async () => { const onOk = jest.fn();
+      renderModal('Hey', { onOk });
+      fireEvent.keyDown(document, {
+        key: 'Enter'
+      })
+
+      expect(onOk)
+        .toBeCalled();
+    });
+
+    it('calls onCancel on pressing ESC', async () => {
+      const onCancel = jest.fn();
+      renderModal('Hey', { onCancel });
+      fireEvent.keyDown(document, {
+        key: 'Escape'
+      })
+      expect(onCancel)
+        .toBeCalled();
+    });
+
+    it ('calls onOk on pressing ESC if showCancelButton is false', async () => {
+      const onOk = jest.fn();
+      renderModal('Hey', { onOk, showCancelButton: false });
+      fireEvent.keyDown(document, {
+        key: 'Escape'
+      })
+      expect(onOk)
+        .toBeCalled();
+    })
+  })
 });
 
 describe('waits for async onOk', () => {

--- a/__tests__/confirm.js
+++ b/__tests__/confirm.js
@@ -67,54 +67,64 @@ it('renders custom button text', async () => {
     .toBe(cancelButtonText);
 });
 
-it('hides modal and resolves true on clicking ok button', async () => {
-  const promise = confirm('Message')
-    .then(result => {
-      expect(result)
-        .toBe(true);
-    });
-  modal = (await screen.findAllByRole('dialog')).find(div => div.classList.contains('rs-modal'));
-  okButton = modal.querySelector('.rs-btn-primary');
-  await act(() => {
-    fireEvent.click(okButton);
-    return promise;
-  });
-});
+describe('resolves correctly', () => {
 
-it('hides modal and resolves false on clicking cancel button', async () => {
-  confirm('Message')
-    .then(result => {
-      expect(result)
-        .toBe(false);
-    });
-  modal = (await screen.findAllByRole('dialog')).find(div => div.classList.contains('rs-modal'));
-  cancelButton = modal.querySelector('.rs-btn-default');
-  act(() => {
+  let promise;
+
+  beforeEach(async () => {
+    promise = confirm('Message');
+    modal = (await screen.findAllByRole('dialog')).find(div => div.classList.contains('rs-modal'));
+    okButton = modal.querySelector('.rs-btn-primary');
+    cancelButton = modal.querySelector('.rs-btn-default');
+  });
+
+  it('hides modal and resolves true on clicking ok button', async () => {
+    fireEvent.click(okButton);
+
+    await expect(promise)
+      .resolves
+      .toBe(true);
+  });
+
+  it('hides modal and resolves false on clicking cancel button', async () => {
     fireEvent.click(cancelButton);
+
+    await expect(promise)
+      .resolves
+      .toBe(false);
+  });
+
+  it('hides modal and resolves true on pressing Enter', async () => {
+    fireEvent.keyDown(document, { key: 'Enter' });
+    await expect(promise)
+      .resolves
+      .toBe(true);
+  });
+
+  it('hides modal and false true on pressing Esc', async () => {
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await expect(promise)
+      .resolves
+      .toBe(false);
   });
 });
 
 it('calls onOk on clicking ok button', async () => {
   const onOk = jest.fn();
-  await act(async () => {
-    await openConfirm('Message', {
-      onOk
-    });
-    fireEvent.click(okButton);
+  await openConfirm('Message', {
+    onOk
   });
-
+  fireEvent.click(okButton);
   expect(onOk)
     .toBeCalled();
 });
 
 it('calls onCancel on clicking cancel button', async () => {
   const onCancel = jest.fn();
-  await act(async () => {
-    await openConfirm('Message', {
-      onCancel
-    });
-    fireEvent.click(cancelButton);
+  await openConfirm('Message', {
+    onCancel
   });
+  fireEvent.click(cancelButton);
 
   expect(onCancel)
     .toBeCalled();

--- a/__tests__/prompt.js
+++ b/__tests__/prompt.js
@@ -77,47 +77,45 @@ it('renders custom button text', async () => {
     .toBe(cancelButtonText);
 });
 
-it('hides modal and resolves input value on clicking ok button', async () => {
+describe('resolves correctly', () => {
+  let promise;
   const inputValue = 'Input value';
-  const promise = prompt('Message');
-  modal = (await screen.findAllByRole('dialog')).find(div => div.classList.contains('rs-modal'));
-  input = modal.querySelector('input');
-  okButton = modal.querySelector('.rs-btn-primary');
-  await userEvent.type(input, inputValue);
-  act(() => {
-    fireEvent.click(okButton);
+  beforeEach(async () => {
+    promise = prompt('Message');
+    modal = (await screen.findAllByRole('dialog')).find(div => div.classList.contains('rs-modal'));
+    input = modal.querySelector('input');
+    userEvent.type(input, inputValue);
   });
-  expect(promise)
-    .resolves
-    .toBe(inputValue);
-  await act(() => promise);
-});
 
-it('hides modal and resolves default value on clicking ok button', async () => {
-  const defaultValue = 'Default value';
-  const promise = prompt('Message', defaultValue);
-  modal = (await screen.findAllByRole('dialog')).find(div => div.classList.contains('rs-modal'));
-  okButton = modal.querySelector('.rs-btn-primary');
-  act(() => {
+  it('hides modal and resolves input value on clicking ok button', async () => {
+    okButton = modal.querySelector('.rs-btn-primary');
     fireEvent.click(okButton);
+    await expect(promise)
+      .resolves
+      .toBe(inputValue);
   });
-  expect(promise)
-    .resolves
-    .toBe(defaultValue);
-  await act(() => promise);
-});
 
-it('hides modal and resolves null on clicking cancel button', async () => {
-  const promise = prompt('Message');
-  modal = (await screen.findAllByRole('dialog')).find(div => div.classList.contains('rs-modal'));
-  cancelButton = modal.querySelector('.rs-btn-default');
-  act(() => {
+  it('hides modal and resolves null on clicking cancel button', async () => {
+    cancelButton = modal.querySelector('.rs-btn-default');
     fireEvent.click(cancelButton);
+    await expect(promise)
+      .resolves
+      .toBe(null);
   });
-  expect(promise)
-    .resolves
-    .toBe(null);
-  await act(() => promise);
+
+  it('hides modal and resolves input value on pressing Enter', async () => {
+    fireEvent.keyDown(document, { key: 'Enter' });
+    await expect(promise)
+      .resolves
+      .toBe(inputValue);
+  });
+
+  it('hides modal and resolves null on pressing Esc', async () => {
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await expect(promise)
+      .resolves
+      .toBe(null);
+  });
 });
 
 it('calls onOk on clicking ok button', async () => {

--- a/src/InteractionModal.js
+++ b/src/InteractionModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Button, Modal } from 'rsuite';
 
 function InteractionModal({
@@ -36,6 +36,34 @@ function InteractionModal({
     // pass current loading status to onCancel to distinguish different case
     onCancel && onCancel(submitLoading);
   }, [onCancel, submitLoading]);
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleOk();
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (showCancelButton) {
+          handleCancel();
+        } else {
+          handleOk();
+        }
+      }
+    }
+
+    if (shouldShowModal) {
+
+      document.addEventListener('keydown', handleKeyDown, false);
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown, false);
+      };
+    }
+  }, [shouldShowModal, handleOk, handleCancel, showCancelButton]);
 
   return (
     <Modal size="xs" show={shouldShowModal}>


### PR DESCRIPTION
See #12 
Modals should respond to <kbd>Esc</kbd> and <kbd>Enter</kbd>, representing `Cancel` and `OK` button clicks. 

|Modal|<kbd>Esc</kbd> pressed|<kbd>Enter</kbd> pressed|
|------|---------------|----------------|
|alert|closes modal|closes modal|
|confirm|closes modal and resolves `false`|closes modal and resolves `true`|
|prompt|closes modal and resolves `null`|closes modal and resolves input value/default value|